### PR TITLE
PHP 5.3+ compatibility fix

### DIFF
--- a/app/code/community/EcomDev/ProductPageShipping/Model/Session.php
+++ b/app/code/community/EcomDev/ProductPageShipping/Model/Session.php
@@ -23,10 +23,10 @@
  */
 class EcomDev_ProductPageShipping_Model_Session extends Mage_Core_Model_Session_Abstract
 {
-    const NAMESPACE = 'productpageshipping';
+    const PRODUCTPAGESHIPPING_NAMESPACE = 'productpageshipping';
 
     public function __construct()
     {
-        $this->init(self::NAMESPACE);
+        $this->init(self::PRODUCTPAGESHIPPING_NAMESPACE);
     }
 }


### PR DESCRIPTION
NAMESPACE is a reserved word in PHP 5.3+, renaming the constant so that this file no longer produces a parse error.
